### PR TITLE
Using float instead of numpy.float

### DIFF
--- a/hopmaAnal.py
+++ b/hopmaAnal.py
@@ -34,7 +34,7 @@ def calc_residue_dist_min(resid1, resid2) :
 
 def calc_dist_matrix(chain_one, chain_two) :
     """Returns a matrix of C-alpha distances between two chains"""
-    answer = numpy.zeros((len(chain_one), len(chain_two)), numpy.float)
+    answer = numpy.zeros((len(chain_one), len(chain_two)), float)
     for row, residue_one in enumerate(chain_one) :
     	#print row, residue_one
         for col, residue_two in enumerate(chain_two) :


### PR DESCRIPTION
Using numpy.float is deprecated as of numpy 1.20 and removed as of numpy 1.24.

numpy.float is identical to float, so the change is completely safe while at the same time allowing newer versions of numpy to be used